### PR TITLE
fix: 修复 autodelcmd 误删正常发言的问题

### DIFF
--- a/autodelcmd/autodelcmd.ts
+++ b/autodelcmd/autodelcmd.ts
@@ -437,18 +437,23 @@ class AutoDeleteService {
       console.log(`[autodelcmd] 匹配规则: ${originalCommand}${paramStr} -> ${matchedRule.delay}秒延迟, 删除响应: ${!!matchedRule.deleteResponse}`);
       
       if (matchedRule.deleteResponse) {
-        // 删除命令及相关响应（仅删除紧跟命令的 bot 响应，不删正常发言）
+        // 删除命令及 TeleBox 的响应消息
+        // 安全策略：只删除命令消息本身 + 紧跟其后的 bot 响应（最多3条）
+        // 不会删除用户的正常发言
         try {
           const chatId = msg.chatId || msg.peerId;
-          const messages = await safeGetMessages(this.client, chatId, { limit: 20 });
+          // 获取命令消息之后的少量消息（limit 设为 MAX_RESPONSE_MESSAGES + buffer）
+          const messages = await safeGetMessages(this.client, chatId, { limit: 10 });
 
-          // 查找最近的响应消息并删除
-          // 在 Saved Messages 中，需要特殊处理消息的归属
           const msgChatId = this.getChatId(msg);
           const isInSavedMessages = cachedUserId && msgChatId?.toString() === cachedUserId;
           
           let deletedCount = 0;
-          const MAX_RESPONSE_MESSAGES = 3; // 最多删除3条响应消息
+          const MAX_RESPONSE_MESSAGES = 3;
+          
+          // 安全策略：只删除 ID 刚好紧跟命令消息的响应
+          // 如果遇到 ID 大于 msg.id 但间隔超过 5 的消息，停止查找（说明中间有用户正常发言隔开了）
+          const ID_GAP_THRESHOLD = 5;
           
           for (const message of messages) {
             // 跳过命令消息本身
@@ -457,29 +462,46 @@ class AutoDeleteService {
             // 达到删除上限，停止查找
             if (deletedCount >= MAX_RESPONSE_MESSAGES) break;
             
+            // 只处理 ID 大于命令消息 ID 的消息（命令之后发送的）
+            if (message.id <= msg.id) continue;
+            
+            // 安全检查：如果消息 ID 与命令 ID 间隔过大，说明不是紧跟的响应，停止查找
+            if (message.id - msg.id > ID_GAP_THRESHOLD + deletedCount) {
+              console.log(`[autodelcmd] 消息 ID ${message.id} 与命令 ID ${msg.id} 间隔过大，停止查找`);
+              break;
+            }
+            
             let shouldDelete = false;
             
             if (isInSavedMessages) {
-              // 在 Saved Messages 中，查找消息ID大于命令消息ID的最近消息作为响应
-              // 因为响应通常在命令之后发送，ID会更大，但获取的消息列表是按时间倒序的
-              if (message.id > msg.id) {
-                shouldDelete = true;
-              }
+              // 在 Saved Messages 中，ID 更大且紧跟命令的就是 bot 响应
+              shouldDelete = true;
             } else {
-              // 在普通聊天中，只删除 bot 发出的响应消息（fromId 指向 bot 或 viaBotId）
-              // 不删除用户自己的正常发言（message.out === true 且无 fromId）
-              const isFromBot = message.fromId || (message as any).viaBotId;
+              // 在普通聊天中，需要区分 bot 响应和用户正常发言
+              // bot 响应特征：viaBotId（通过 bot 发送）或 fromId（bot 账号发送）
+              // 用户正常发言：message.out === true 且无 fromId/viaBotId
+              const viaBotId = (message as any).viaBotId;
+              const fromId = (message as any).fromId;
               const isOwnOutgoing = message.out === true;
-              // 只删除 bot 响应：非自己发出的消息，或自己通过 bot 发出的消息
-              if (!isOwnOutgoing || isFromBot) {
+              
+              if (viaBotId || fromId) {
+                // bot 发出的响应
+                shouldDelete = true;
+              } else if (!isOwnOutgoing) {
+                // 非本人发出的消息（其他人的消息或其他 bot 的消息）
                 shouldDelete = true;
               }
+              // 否则：message.out === true 且无 fromId/viaBotId = 用户正常发言，不删除
             }
             
             if (shouldDelete) {
               console.log(`[autodelcmd] 找到响应消息 ID ${message.id}，将一同删除 (${deletedCount + 1}/${MAX_RESPONSE_MESSAGES})`);
               await this.delayDelete(message, matchedRule.delay);
               deletedCount++;
+            } else {
+              // 遇到不该删除的消息（用户正常发言），停止查找
+              console.log(`[autodelcmd] 消息 ID ${message.id} 不是 bot 响应，停止查找`);
+              break;
             }
           }
           

--- a/autodelcmd/autodelcmd.ts
+++ b/autodelcmd/autodelcmd.ts
@@ -2,7 +2,7 @@
 import { Api } from "teleproto";
 import { Plugin , type PanelSettingsAdapter, type PanelSettingField } from "@utils/pluginBase";
 import { getGlobalClient } from "@utils/runtimeManager";
-import { getPrefixes } from "@utils/pluginManager";
+import { getPrefixes, listCommands } from "@utils/pluginManager";
 import { AliasDB } from "@utils/aliasDB";
 import { createDirectoryInAssets } from "@utils/pathHelpers";
 import fs from "fs/promises";
@@ -437,10 +437,10 @@ class AutoDeleteService {
       console.log(`[autodelcmd] 匹配规则: ${originalCommand}${paramStr} -> ${matchedRule.delay}秒延迟, 删除响应: ${!!matchedRule.deleteResponse}`);
       
       if (matchedRule.deleteResponse) {
-        // 删除命令及相关响应
+        // 删除命令及相关响应（仅删除紧跟命令的 bot 响应，不删正常发言）
         try {
           const chatId = msg.chatId || msg.peerId;
-          const messages = await safeGetMessages(this.client, chatId, { limit: 100 });
+          const messages = await safeGetMessages(this.client, chatId, { limit: 20 });
 
           // 查找最近的响应消息并删除
           // 在 Saved Messages 中，需要特殊处理消息的归属
@@ -466,8 +466,12 @@ class AutoDeleteService {
                 shouldDelete = true;
               }
             } else {
-              // 在普通聊天中，查找自己发出的消息
-              if (message.out) {
+              // 在普通聊天中，只删除 bot 发出的响应消息（fromId 指向 bot 或 viaBotId）
+              // 不删除用户自己的正常发言（message.out === true 且无 fromId）
+              const isFromBot = message.fromId || (message as any).viaBotId;
+              const isOwnOutgoing = message.out === true;
+              // 只删除 bot 响应：非自己发出的消息，或自己通过 bot 发出的消息
+              if (!isOwnOutgoing || isFromBot) {
                 shouldDelete = true;
               }
             }
@@ -720,44 +724,43 @@ class AutoDeletePlugin extends Plugin {
     }
   }
 
-  description: string = `🗑️ 自动删除命令消息插件
+  description: string = `🗑️ <b>自动删除命令消息插件</b>
 
 <b>功能说明:</b>
-- 自动监听并延迟删除特定命令的消息
-- 支持所有配置的自定义前缀和别名命令
-- 支持自定义删除规则和延迟时间
-- 首次运行自动创建配置文件，包含预设的默认规则
+• 自动监听并延迟删除特定命令的消息
+• 支持所有配置的自定义前缀和别名命令
+• 支持自定义删除规则和延迟时间
+• 首次运行自动创建配置文件，包含预设的默认规则
 
 <b>消息处理范围:</b>
-- 自己发出的所有命令消息
-- Saved Messages（收藏夹）中的命令消息
+• 自己发出的已注册命令消息
+• Saved Messages（收藏夹）中的命令消息
 
 <b>配置管理命令:</b>
-• <code>${mainPrefix}autodelcmd on/off</code> - 启用/禁用自动删除功能
-• <code>${mainPrefix}autodelcmd status</code> - 查看功能状态和规则统计
-• <code>${mainPrefix}autodelcmd list</code> - 查看所有规则
-• <code>${mainPrefix}autodelcmd add [命令] [延迟秒数] [参数1] [参数2] [...] [-r] [-e]</code> - 添加规则
-• <code>${mainPrefix}autodelcmd del [规则ID或命令名]</code> - 删除规则或查看规则
-• <code>${mainPrefix}autodelcmd reset</code> - 重置为默认配置
+<code>${mainPrefix}autodelcmd on</code> - 启用自动删除功能
+<code>${mainPrefix}autodelcmd off</code> - 禁用自动删除功能
+<code>${mainPrefix}autodelcmd status</code> - 查看功能状态和规则统计
+<code>${mainPrefix}autodelcmd list</code> - 查看所有规则
+<code>${mainPrefix}autodelcmd add &lt;命令&gt; &lt;延迟秒数&gt; [参数...] [-r] [-e]</code> - 添加规则
+<code>${mainPrefix}autodelcmd del &lt;规则ID或命令名&gt;</code> - 删除规则或查看规则
+<code>${mainPrefix}autodelcmd reset</code> - 重置为默认配置
 
 <b>特殊选项:</b>
-• 🔄 使用 <code>-r</code> 或 <code>--response</code> 参数启用删除响应消息
-• 删除响应指同时删除命令触发的最近一条回复消息
-• 🎯 使用 <code>-e</code> 或 <code>--exact</code> 参数启用精确匹配模式
-• 精确匹配只匹配无参数的命令调用，不匹配带参数的调用
+🔄 <code>-r</code> / <code>--response</code> - 同时删除响应消息
+🎯 <code>-e</code> / <code>--exact</code> - 精确匹配（只匹配无参数调用）
 
 <b>使用示例:</b>
-• <code>${mainPrefix}autodelcmd list</code> - 查看所有配置规则
-• <code>${mainPrefix}autodelcmd add ping 30</code> - ping命令30秒后删除
-• <code>${mainPrefix}autodelcmd add speedtest 60 -r</code> - speedtest命令60秒后删除（🔄包含响应）
-• <code>${mainPrefix}autodelcmd add tpm 60 list ls search</code> - tpm list/ls/search任一命令60秒后删除
-• <code>${mainPrefix}autodelcmd add ping 30 -e</code> - 只有无参数的ping命令30秒后删除
-• <code>${mainPrefix}autodelcmd del ping</code> - 查看ping命令的所有规则
-• <code>${mainPrefix}autodelcmd del 1</code> - 使用ID删除指定规则
-• <code>${mainPrefix}autodelcmd reset</code> - 重置为默认配置
+<code>${mainPrefix}autodelcmd list</code>
+<code>${mainPrefix}autodelcmd add ping 30</code>
+<code>${mainPrefix}autodelcmd add speedtest 60 -r</code>
+<code>${mainPrefix}autodelcmd add tpm 60 list ls search</code>
+<code>${mainPrefix}autodelcmd add ping 30 -e</code>
+<code>${mainPrefix}autodelcmd del ping</code>
+<code>${mainPrefix}autodelcmd del 1</code>
+<code>${mainPrefix}autodelcmd reset</code>
 
 <b>配置文件位置:</b>
-配置文件保存在 <code>assets/autodelcmd/config.json</code>，可直接编辑修改规则。
+<code>assets/autodelcmd/config.json</code> 可直接编辑修改规则。
 
 <b>注意:</b> 插件默认处于禁用状态，需要手动启用才能工作。首次运行会自动创建配置文件并写入默认规则。`;
 
@@ -1160,6 +1163,15 @@ class AutoDeletePlugin extends Plugin {
       const parameters = parts.slice(1); // 其余都是参数
       
       if (!command) return; // 如果只有前缀没有命令，跳过
+
+      // 验证命令是否已注册：只有真正的命令调用才需要自动删除
+      // 避免误删正常发言（如用户输入 ".ping" 作为普通文字）
+      const registeredCommands = listCommands();
+      const resolvedCommand = resolveAlias(command);
+      if (!registeredCommands.includes(resolvedCommand)) {
+        console.log(`[autodelcmd] 跳过非命令消息: ${command} (未注册的命令)`);
+        return;
+      }
       
       console.log(`[autodelcmd] 检测到命令: ${command}, 参数: ${JSON.stringify(parameters)}, 前缀: ${matchedPrefix}, 原始消息: ${messageText}`);
 


### PR DESCRIPTION
## 修复内容

### 1. 命令注册验证
- 添加 `listCommands()` 验证：只处理已注册的命令
- 避免误删以命令前缀开头的正常发言

### 2. deleteResponse 误删修复
- 之前：删除所有 `message.out === true` 的消息（最多3条）
- 现在：只删除 bot 发出的响应消息，不碰用户的正常发言

### 3. 帮助文本优化
- 所有命令示例使用 `<code>` 标签包裹，Telegram 中以代码块展示

## 测试
- 已替换到本地 TeleBox 并通过 `pm2 reload telebox` 重载验证